### PR TITLE
added support for bootJar leveransepakke

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=3.4.7
+version=3.5.0
 groupId=no.skatteetaten.aurora.gradle.plugins
 artifactId=aurora-gradle-plugin

--- a/src/main/groovy/no/skatteetaten/aurora/gradle/plugins/AuroraPlugin.groovy
+++ b/src/main/groovy/no/skatteetaten/aurora/gradle/plugins/AuroraPlugin.groovy
@@ -22,6 +22,7 @@ class AuroraPlugin implements Plugin<Project> {
       applyJacocoTestReport         : true,
       applyMavenDeployer            : true,
       auroraSpringBootStarterVersion: "2.4.0",
+      useBootJar                    : false,
       springCloudContractVersion    : "2.2.1.RELEASE",
       kotlinLoggingVersion          : "1.7.8",
       checkstyleConfigVersion       : "2.2.4",
@@ -60,11 +61,11 @@ class AuroraPlugin implements Plugin<Project> {
       }
 
       if (config.applyDeliveryBundleConfig.toBoolean()) {
-        reports.add(java.applyDeliveryBundleConfig())
+        reports.add(java.applyDeliveryBundleConfig(config.useBootJar.toBoolean()))
       }
 
       p.plugins.withId("org.springframework.boot") {
-        reports.add(java.applySpring(config.auroraSpringBootStarterVersion, config.springDevTools.toBoolean()))
+        reports.add(java.applySpring(config.auroraSpringBootStarterVersion, config.springDevTools.toBoolean(), config.useBootJar.toBoolean()))
       }
 
       if (config.applyJunit5Support.toBoolean()) {

--- a/src/main/groovy/no/skatteetaten/aurora/gradle/plugins/JavaApplicationTools.groovy
+++ b/src/main/groovy/no/skatteetaten/aurora/gradle/plugins/JavaApplicationTools.groovy
@@ -212,13 +212,7 @@ class JavaApplicationTools {
       }
     }
 
-    def resolvedBootJarText = {
-      if (bootJarEnabled) {
-        "."
-      } else {
-        ", bootJar disabled."
-      }
-    }
+    def resolvedBootJarText = bootJarEnabled ? "" : ", bootJar disabled"
 
     return new AuroraReport(
         name: "plugin org.springframework.boot",

--- a/src/main/groovy/no/skatteetaten/aurora/gradle/plugins/JavaApplicationTools.groovy
+++ b/src/main/groovy/no/skatteetaten/aurora/gradle/plugins/JavaApplicationTools.groovy
@@ -176,8 +176,7 @@ class JavaApplicationTools {
         ])
   }
 
-  AuroraReport applySpring(String starterVersion, Boolean devTools) {
-
+  AuroraReport applySpring(String starterVersion, Boolean devTools, Boolean bootJarEnabled) {
     def implementationDependencies = [
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
         "no.skatteetaten.aurora.springboot:aurora-spring-boot2-starter:$starterVersion",
@@ -185,39 +184,49 @@ class JavaApplicationTools {
     if (devTools) {
       implementationDependencies.add("org.springframework.boot:spring-boot-devtools")
     }
-    log.info("Apply Spring support")
-    project.with {
 
+    log.info("Apply Spring support")
+
+    project.with {
       apply plugin: 'io.spring.dependency-management'
 
-      [jar, distZip]*.enabled = true
-      [bootJar, distTar, bootDistTar, bootDistZip]*.enabled = false
+      if (!bootJarEnabled) {
+        [jar, distZip]*.enabled = true
+        [bootJar, distTar, bootDistTar, bootDistZip]*.enabled = false
 
-      configurations.archives.artifacts.removeIf {
-        if (it.hasProperty("archiveTask")) {
-          !it.archiveTask.enabled
-        } else {
-          !it.delegate.archiveTask.enabled
+        configurations.archives.artifacts.removeIf {
+          if (it.hasProperty("archiveTask")) {
+            !it.archiveTask.enabled
+          } else {
+            !it.delegate.archiveTask.enabled
+          }
         }
       }
 
       springBoot {
         buildInfo()
       }
-      dependencies {
 
+      dependencies {
         implementationDependencies.each { implementation it }
       }
-
     }
+
+    def resolvedBootJarText = {
+      if (bootJarEnabled) {
+        "."
+      } else {
+        ", bootJar disabled."
+      }
+    }
+
     return new AuroraReport(
         name: "plugin org.springframework.boot",
         dependenciesAdded: implementationDependencies.collect {
           "implementation $it"
         },
-        description: "Build info, disable fat jar. Optional devtools",
+        description: "Build info${resolvedBootJarText()} Optional devtools",
         pluginsApplied: ["io.spring.dependency-management"])
-
   }
 
   AuroraReport applyDefaultPlugins() {
@@ -311,17 +320,45 @@ class JavaApplicationTools {
         description: "only allow stable versions in upgrade")
   }
 
-  AuroraReport applyDeliveryBundleConfig() {
+  AuroraReport applyDeliveryBundleConfig(Boolean bootJar) {
+    if (bootJar) {
+      project.with {
+        apply plugin: 'distribution'
 
-    project.with {
-      apply plugin: 'application'
+        distributions {
+          main {
+            contents {
+              from("${buildDir}/libs") {
+                into('lib')
+              }
 
-      distZip.classifier = 'Leveransepakke'
-      startScripts.enabled = false
+              from("${projectDir}/src/main/dist/metadata") {
+                into('metadata')
+              }
+            }
+          }
+        }
+
+        distZip {
+          dependsOn 'bootJar'
+          archiveClassifier = 'Leveransepakke'
+        }
+      }
+
+      return new AuroraReport(name: "aurora.applyDeliveryBundleConfig",
+              pluginsApplied: ["distribution"],
+              description: "Configure Leveransepakke for bootJar")
+    } else {
+      project.with {
+        apply plugin: 'application'
+
+        distZip.classifier = 'Leveransepakke'
+        startScripts.enabled = false
+      }
+
+      return new AuroraReport(name: "aurora.applyDeliveryBundleConfig", pluginsApplied: ["application"],
+              description: "Configure Leveransepakke")
     }
-
-    return new AuroraReport(name: "aurora.applyDeliveryBundleConfig", pluginsApplied: ["application"],
-        description: "Configure Leveransepakke")
   }
 
   AuroraReport applyAsciiDocPlugin() {


### PR DESCRIPTION
Can now enable a "bootJar leveransepakke" by setting _aurora.useBootJar=true_ in gradle properties. Default is false, which makes the plugin backward compatible with existing implementations.

The leveransepakke will have the same structure like so:

lib/"application jar"
metadata/openshift.json

Because radish runs with the -cp command any application using this kind of leveransepakke must specify _org.springframework.boot.loader.JarLauncher_ as their mainclass in openshift.json

No changes are required in any other services (architect, radish etc.)

Semantic version increase to 3.5.0.