### PR TITLE
set failOnNoContracts to false

### DIFF
--- a/src/main/groovy/no/skatteetaten/aurora/gradle/plugins/JavaApplicationTools.groovy
+++ b/src/main/groovy/no/skatteetaten/aurora/gradle/plugins/JavaApplicationTools.groovy
@@ -52,6 +52,7 @@ class JavaApplicationTools {
       }
       contracts {
         packageWithBaseClasses = "${groupId}.${artifactId}.contracts"
+        failOnNoContracts = false
 
         if (junit5) {
           testFramework = "JUNIT5"


### PR DESCRIPTION
Bygget feiler med nyere versjoner av spring cloud contract gradle plugin (2.2.x) pga propertyen `failOnNoContracts` er default satt til `true`. Må sette denne til false, siden vi ikke sette opp DSL kontrakter men bruker restdoc tester til å generere kontraktene.
https://cloud.spring.io/spring-cloud-contract/reference/html/gradle-project.html#gradle-configuration-options