### PR TITLE
Version bumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ However any plugins specified with a version that differs from the compiled plug
 
 Since this plugin is intended for use by JVM based applications, and since the NTA heavily relies on Nexus for artifact
 dependency management and artifact distribution, both the java and maven plugin will be applied automatically. The
-```sourceCompatibility``` will be set to 1.8 by default. This can be changed in the `aurora` block like this:
+```sourceCompatibility``` will be set to 11 by default. This can be changed in the `aurora` block like this:
 
     aurora {
         versions {
@@ -138,7 +138,7 @@ dependency management and artifact distribution, both the java and maven plugin 
         }
     }
 
-If you set the properties ```repositoryUsername```, ```repositoryPassword```, ```repositoryReleaseUrl``` and ```repositorySnapshotUrl``` in your ```~/gradle/.gradle.properties```-file the plugin will register Maven deployer for both snapshots and releases.
+If you set the properties ```repositoryUsername```, ```repositoryPassword```, ```repositoryReleaseUrl``` and ```repositorySnapshotUrl``` in your ```~/.gradle/gradle.properties```-file the plugin will register Maven deployer for both snapshots and releases.
 
 These features can be opted out of with the following config;
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,6 @@ import org.jlleitschuh.gradle.ktlint.KtlintFormatTask
 
 plugins {
     kotlin("jvm") version(Versions.kotlin)
-    `kotlin-dsl`
 
     id("idea")
     id("java-gradle-plugin")
@@ -27,6 +26,9 @@ repositories {
 }
 
 dependencies {
+    implementation(gradleKotlinDsl())
+    implementation("org.jetbrains.kotlin:kotlin-reflect:${Versions.kotlin}")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:${Versions.kotlin}")
     implementation(fileTree("$rootDir/buildSrc/build/libs") { include("*.jar") })
     implementation("io.github.microutils:kotlin-logging:${Versions.kotlinLogging}")
     implementation("org.springframework.boot:spring-boot-gradle-plugin:${PluginVersions.spring_boot}")
@@ -66,10 +68,6 @@ pluginBundle {
     tags = setOf("skatteetaten", "corporate")
 }
 
-kotlinDslPluginOptions {
-    experimentalWarning.set(false)
-}
-
 testlogger {
     theme = STANDARD_PARALLEL
     showStandardStreams = true
@@ -96,10 +94,12 @@ tasks {
         distributionType = Wrapper.DistributionType.ALL
     }
 
-    @Suppress("UNUSED_VARIABLE")
-    val compileKotlin by existing(KotlinCompile::class) {
+    withType(KotlinCompile::class).configureEach {
         kotlinOptions {
-            languageVersion = Versions.kotlin
+            suppressWarnings = true
+            jvmTarget = Versions.javaSourceCompatibility
+            freeCompilerArgs = listOf("-nowarn")
+            languageVersion = Versions.kotlin.substringBeforeLast(".")
         }
 
         dependsOn(listOf(ktlintKotlinScriptFormat, ktlintFormat))

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,5 +1,5 @@
 object Versions {
-    const val javaSourceCompatibility: String = "1.11"
+    const val javaSourceCompatibility: String = "11"
     const val groovy: String = "3.0.5"
     const val spock: String = "1.3-groovy-2.5"
     const val junit5: String = "5.7.0"
@@ -8,17 +8,17 @@ object Versions {
     const val auroraSpringBootMvcStarter: String = "1.0.+"
     const val auroraSpringBootWebFluxStarter: String = "1.0.+"
     const val springCloudContract: String = "2.2.4.RELEASE"
-    const val kotlinLogging: String = "1.11.3"
+    const val kotlinLogging: String = "2.0.3"
     const val checkstyleConfig: String = "2.2.5"
     const val checkstyleConfigFile: String = "checkstyle/checkstyle-with-metrics.xml"
-    const val kotlin = "1.3.72"
+    const val kotlin = "1.4.10"
     const val assertk = "0.22"
 }
 
 object PluginVersions {
     const val gradle_test_logger = "2.1.0"
-    const val ktlint = "9.3.0"
-    const val spring_boot = "2.3.3.RELEASE"
+    const val ktlint = "9.4.0"
+    const val spring_boot = "2.3.4.RELEASE"
     const val ben_manes_versions = "0.33.0"
     const val gradle_plugin_publish = "0.12.0"
     const val asciidoctor = "2.4.0"
@@ -27,7 +27,7 @@ object PluginVersions {
     const val dependency_management = "1.0.10.RELEASE"
     const val sonar = "3.0"
     const val git_properties = "2.2.3"
-    const val latest_versions = "0.2.14"
+    const val latest_versions = "0.2.15"
 }
 
 object Features {

--- a/src/main/kotlin/no/skatteetaten/aurora/gradle/plugins/AuroraPlugin.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gradle/plugins/AuroraPlugin.kt
@@ -25,10 +25,10 @@ import org.gradle.kotlin.dsl.getByType
 @Suppress("unused")
 @ExperimentalStdlibApi
 class AuroraPlugin : Plugin<Project> {
-    override fun apply(project: Project) {
-        project.configureExtensions()
-        project.afterEvaluate {
-            logger.lifecycle("After evaluate")
+    override fun apply(p: Project) {
+        p.configureExtensions()
+        p.afterEvaluate { project ->
+            project.logger.lifecycle("After evaluate")
 
             val config = project.getConfig()
             val java = Java(project, config)
@@ -51,20 +51,24 @@ class AuroraPlugin : Plugin<Project> {
                 miscellaneous.configure()
             ).flatten()
 
-            with(tasks) {
+            with(project.tasks) {
                 register("aurora") {
-                    logger.lifecycle(
-                        "Use task :aurora to get full report on how AuroraPlugin modifies your gradle setup"
-                    )
+                    with(it) {
+                        project.logger.lifecycle(
+                            "Use task :aurora to get full report on how AuroraPlugin modifies your gradle setup"
+                        )
 
-                    doLast {
-                        printReport(reports)
+                        doLast {
+                            printReport(reports)
+                        }
                     }
                 }
 
                 register("auroraConfiguration") {
-                    doLast {
-                        logger.lifecycle(config.toString())
+                    with(it) {
+                        doLast {
+                            project.logger.lifecycle(config.toString())
+                        }
                     }
                 }
             }

--- a/src/main/kotlin/no/skatteetaten/aurora/gradle/plugins/configurators/Kotlin.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gradle/plugins/configurators/Kotlin.kt
@@ -16,7 +16,8 @@ class Kotlin(
         project.plugins.withId("org.jetbrains.kotlin.jvm") {
             add(
                 tools.applyKotlinSupport(
-                    kotlinLoggingVersion = config.kotlinLoggingVersion
+                    kotlinLoggingVersion = config.kotlinLoggingVersion,
+                    sourceCompatibility = config.javaSourceCompatibility
                 )
             )
         }

--- a/src/main/kotlin/no/skatteetaten/aurora/gradle/plugins/extensions/AuroraExtension.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gradle/plugins/extensions/AuroraExtension.kt
@@ -35,7 +35,9 @@ open class AuroraExtension(private val project: Project) {
         useSpringBoot()
 
         features {
-            checkstylePlugin = true
+            with(it) {
+                checkstylePlugin = true
+            }
         }
 
         return this

--- a/src/main/kotlin/no/skatteetaten/aurora/gradle/plugins/mutators/AuroraTools.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gradle/plugins/mutators/AuroraTools.kt
@@ -16,13 +16,13 @@ class AuroraTools(private val project: Project) {
 
                 with(extensions.getByName("distributions") as DistributionContainer) {
                     with(getByName("main")) {
-                        contents {
+                        with(contents) {
                             from("${project.buildDir}/libs") {
-                                into("lib")
+                                it.into("lib")
                             }
 
                             from("${project.projectDir}/src/main/dist/metadata") {
-                                into("metadata")
+                                it.into("metadata")
                             }
                         }
                     }

--- a/src/main/kotlin/no/skatteetaten/aurora/gradle/plugins/mutators/KotlinTools.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gradle/plugins/mutators/KotlinTools.kt
@@ -7,7 +7,10 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jlleitschuh.gradle.ktlint.KtlintExtension
 
 class KotlinTools(private val project: Project) {
-    fun applyKotlinSupport(kotlinLoggingVersion: String): AuroraReport {
+    fun applyKotlinSupport(
+        kotlinLoggingVersion: String,
+        sourceCompatibility: String
+    ): AuroraReport {
         project.logger.lifecycle("Apply kotlin support")
 
         val implementationDependencies = listOf(
@@ -22,9 +25,9 @@ class KotlinTools(private val project: Project) {
             }
 
             tasks.withType(KotlinCompile::class).configureEach {
-                kotlinOptions {
+                with(it.kotlinOptions) {
                     suppressWarnings = true
-                    jvmTarget = "1.8"
+                    jvmTarget = sourceCompatibility
                     freeCompilerArgs = listOf("-Xjsr305=strict")
                 }
             }

--- a/src/main/kotlin/no/skatteetaten/aurora/gradle/plugins/mutators/MavenTools.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gradle/plugins/mutators/MavenTools.kt
@@ -58,21 +58,23 @@ class MavenTools(private val project: Project) {
         repositoryPassword: String,
         repositorySnapshotUrl: String
     ) = named("uploadArchives", Upload::class.java) {
-        repositories {
-            withConvention(MavenRepositoryHandlerConvention::class) {
-                mavenDeployer {
-                    withGroovyBuilder {
-                        "repository"("url" to repositoryReleaseUrl) {
-                            "authentication"(
-                                "userName" to repositoryUsername,
-                                "password" to repositoryPassword
-                            )
-                        }
-                        "snapshotRepository"("url" to repositorySnapshotUrl) {
-                            "authentication"(
-                                "userName" to repositoryUsername,
-                                "password" to repositoryPassword
-                            )
+        with(it) {
+            with(repositories) {
+                withConvention(MavenRepositoryHandlerConvention::class) {
+                    with(mavenDeployer()) {
+                        withGroovyBuilder {
+                            "repository"("url" to repositoryReleaseUrl) {
+                                "authentication"(
+                                    "userName" to repositoryUsername,
+                                    "password" to repositoryPassword
+                                )
+                            }
+                            "snapshotRepository"("url" to repositorySnapshotUrl) {
+                                "authentication"(
+                                    "userName" to repositoryUsername,
+                                    "password" to repositoryPassword
+                                )
+                            }
                         }
                     }
                 }

--- a/src/main/kotlin/no/skatteetaten/aurora/gradle/plugins/mutators/MiscellaneousTools.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gradle/plugins/mutators/MiscellaneousTools.kt
@@ -16,14 +16,14 @@ class MiscellaneousTools(private val project: Project) {
                 outputFormatter = "json"
                 outputDir = "build/dependencyUpdates"
                 reportfileName = "report"
-                resolutionStrategy {
-                    componentSelection {
-                        all {
+                resolutionStrategy { strategy ->
+                    strategy.componentSelection { selection ->
+                        selection.all { all ->
                             val rejectionPatterns = listOf("alpha", "beta", "pr", "rc", "cr", "m", "preview")
                             val regex: (String) -> Regex = { Regex("(?i).*[.-]$it[.\\d-]*") }
 
-                            if (rejectionPatterns.any { candidate.version.matches(regex(it)) }) {
-                                reject("Release candidate")
+                            if (rejectionPatterns.any { all.candidate.version.matches(regex(it)) }) {
+                                all.reject("Release candidate")
                             }
                         }
                     }

--- a/src/main/kotlin/no/skatteetaten/aurora/gradle/plugins/mutators/SpringTools.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gradle/plugins/mutators/SpringTools.kt
@@ -47,12 +47,12 @@ class SpringTools(private val project: Project) {
 
             if (!bootJarEnabled) {
                 with(tasks) {
-                    getByName("jar") { enabled = true }
-                    getByName("distZip") { enabled = true }
-                    getByName("bootJar") { enabled = false }
-                    getByName("distTar") { enabled = false }
-                    getByName("bootDistTar") { enabled = false }
-                    getByName("bootDistZip") { enabled = false }
+                    getByName("jar") { it.enabled = true }
+                    getByName("distZip") { it.enabled = true }
+                    getByName("bootJar") { it.enabled = false }
+                    getByName("distTar") { it.enabled = false }
+                    getByName("bootDistTar") { it.enabled = false }
+                    getByName("bootDistZip") { it.enabled = false }
                 }
             }
 
@@ -117,7 +117,7 @@ class SpringTools(private val project: Project) {
 
             with(extensions.getByName("dependencyManagement") as DependencyManagementExtension) {
                 imports {
-                    mavenBom(springCloudDep)
+                    it.mavenBom(springCloudDep)
                 }
             }
 
@@ -137,14 +137,16 @@ class SpringTools(private val project: Project) {
             }
 
             val stubsJar = tasks.create("stubsJar", org.gradle.jvm.tasks.Jar::class.java) {
-                archiveClassifier.set("stubs")
+                with(it) {
+                    archiveClassifier.set("stubs")
 
-                into("META-INF/${project.group}/${project.name}/${project.version}/mappings") {
-                    include("**/*.*")
-                    from("${project.buildDir}/generated-snippets/stubs")
+                    into("META-INF/${project.group}/${project.name}/${project.version}/mappings") {
+                        include("**/*.*")
+                        from("${project.buildDir}/generated-snippets/stubs")
+                    }
+
+                    dependsOn("test")
                 }
-
-                dependsOn("test")
             }
 
             with(tasks.named("verifierStubsJar", org.gradle.jvm.tasks.Jar::class).get()) {
@@ -152,7 +154,7 @@ class SpringTools(private val project: Project) {
             }
 
             artifacts {
-                add("archives", stubsJar)
+                it.add("archives", stubsJar)
             }
         }
 

--- a/src/main/kotlin/no/skatteetaten/aurora/gradle/plugins/mutators/TestTools.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gradle/plugins/mutators/TestTools.kt
@@ -31,8 +31,8 @@ class TestTools(private val project: Project) {
             }
 
             tasks.withType(Test::class.java) {
-                useJUnitPlatform()
-                failFast = true
+                it.useJUnitPlatform()
+                it.failFast = true
             }
         }
 
@@ -107,7 +107,7 @@ class TestTools(private val project: Project) {
                     plugins.apply("jacoco")
 
                     tasks.named("jacocoTestReport", JacocoReport::class.java) {
-                        with(reports) {
+                        with(it.reports) {
                             xml.isEnabled = true
                             xml.destination = file("$buildDir/reports/jacoco/report.xml")
                             csv.isEnabled = false

--- a/src/test/kotlin/no/skatteetaten/aurora/gradle/plugins/unit/KotlinToolsTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/gradle/plugins/unit/KotlinToolsTest.kt
@@ -59,13 +59,13 @@ class KotlinToolsTest {
         project.configureExtensions()
         (project as ProjectInternal).evaluate()
         val config = project.getConfig()
-        val report = kotlinTools.applyKotlinSupport(config.kotlinLoggingVersion)
+        val report = kotlinTools.applyKotlinSupport(config.kotlinLoggingVersion, config.javaSourceCompatibility)
         val springReport = springTools.applyKotlinSpringSupport()
 
         project.tasks.withType(KotlinCompile::class).forEach {
             with(it.kotlinOptions) {
                 assertThat(suppressWarnings).isTrue()
-                assertThat(jvmTarget).isEqualTo("1.8")
+                assertThat(jvmTarget).isEqualTo("11")
                 assertThat(freeCompilerArgs).isEqualTo(listOf("-Xjsr305=strict"))
             }
         }


### PR DESCRIPTION
Converted plugin from direct kotlin-dsl to dependency to upgrade kotlin for plugin

Bumped other versions

This will throw classpath conflict warnings - but 1.4.10 will be used for all relevant deps. The 1.3.72 warning comes from bundled kotlin in gradle. Will bump to 1.4 in Gradle 7.

My proposal is that we go to 1.4 before Gradle 7 considering we have good test coverage in the plugin.