### PR TITLE
feature/AOS-5131 Added support for building python leveransepakker

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,10 +23,7 @@ fileLoader.withGit(overrides.pipelineScript,, overrides.scriptVersion) {
 }
 
 jenkinsfile.gradle(overrides.scriptVersion, overrides, {
-
   if(it.isSnapshotVersion) {
-    //it.version="2.2.3-rc4"
     error("Cannot publish snapshot version to gradle plugin portal")
   }
-
 })

--- a/README.md
+++ b/README.md
@@ -169,7 +169,13 @@ You can disable this with;
             deliveryBundle = false
         }
     }
-  
+
+If you are building a python app your delivery bundle will have this format:
+
+    <artifactiId>-<version>-Leveransepakke/
+    <artifactiId>-<version>-Leveransepakke/metadata/<all contents of src/main/dist/metadata>
+    <artifactiId>-<version>-Leveransepakke/src/<all app source from src/main/resources and all deps exploded>
+
 ### Configuration of defaultTasks
 
 defaultTasks will be set to `clean install` if this property has not already been set.
@@ -337,6 +343,13 @@ in your `~/.gradle/gradle.properties` file and be turned of in ci server. They c
         }
     }
 
+### Python
+If python is enabled the jython plugin will be added if missing, and a python leveransepakke will be built, with exploded source:
+
+    aurora {
+        usePython
+    }
+    
 ### Kotlin
 The Aurora plugin will react to Kotlin plugin and add dependencies on kotlin-reflect, stdlib-jdk8 and add 
 kotlinLogging (wrapper for Logback) with the version of. Kotlin will be configured to target
@@ -373,6 +386,7 @@ All configuration options and their default values are shown by running `:aurora
 Complete configuration options for the `aurora` block looks like this:
 
     aurora { 
+        usePython
         useGitProperties
         useLatestVersions
         useAsciiDoctor
@@ -416,6 +430,7 @@ Complete configuration options for the `aurora` block looks like this:
             mavenDeployer = '<enabled>'
             junit5Support = '<enabled>'
             springDevTools = '<enabled>'
+            python = '<enabled>'
         }
     }
 

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -41,6 +41,7 @@ object Features {
     const val applyJunit5Support: Boolean = true
     const val springDevTools: Boolean = false
     const val useWebFlux: Boolean = false
+    const val usePython: Boolean = false
     const val useBootJar: Boolean = false
     const val useAuroraStarters: Boolean = true
 }

--- a/src/main/kotlin/no/skatteetaten/aurora/gradle/plugins/configurators/Aurora.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gradle/plugins/configurators/Aurora.kt
@@ -16,6 +16,7 @@ class Aurora(
         if (config.applyDeliveryBundleConfig) {
             add(
                 tools.applyDeliveryBundleConfig(
+                    python = config.usePython,
                     bootJar = config.useBootJar
                 )
             )

--- a/src/main/kotlin/no/skatteetaten/aurora/gradle/plugins/configurators/Maven.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gradle/plugins/configurators/Maven.kt
@@ -18,7 +18,7 @@ class Maven(
         if (config.applyMavenDeployer) {
             project.logger.lifecycle("Apply maven deployer")
 
-            add(tools.addMavenDeployer())
+            add(tools.addMavenDeployer(python = config.usePython))
         }
     }
 }

--- a/src/main/kotlin/no/skatteetaten/aurora/gradle/plugins/extensions/AuroraExtension.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gradle/plugins/extensions/AuroraExtension.kt
@@ -43,6 +43,21 @@ open class AuroraExtension(private val project: Project) {
         return this
     }
 
+    val usePython: AuroraExtension
+        get() = configurePython()
+
+    fun usePython(): AuroraExtension = configurePython()
+
+    private fun configurePython(): AuroraExtension {
+        features {
+            with(it) {
+                python = true
+            }
+        }
+
+        return this
+    }
+
     val useLatestVersions: AuroraExtension
         get() = configureLatestVersions()
 

--- a/src/main/kotlin/no/skatteetaten/aurora/gradle/plugins/extensions/Features.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gradle/plugins/extensions/Features.kt
@@ -11,4 +11,5 @@ open class Features {
     var junit5Support: Boolean? = null
     var springDevTools: Boolean? = null
     var auroraStarters: Boolean? = null
+    var python: Boolean? = null
 }

--- a/src/main/kotlin/no/skatteetaten/aurora/gradle/plugins/model/AuroraConfiguration.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gradle/plugins/model/AuroraConfiguration.kt
@@ -30,6 +30,7 @@ data class AuroraConfiguration(
     val applyJunit5Support: Boolean = Features.applyJunit5Support,
     val springDevTools: Boolean = Features.springDevTools,
     val useWebFlux: Boolean = Features.useWebFlux,
+    val usePython: Boolean = Features.usePython,
     val useBootJar: Boolean = Features.useBootJar,
     val useAuroraStarters: Boolean = Features.useAuroraStarters
 ) {
@@ -57,6 +58,7 @@ data class AuroraConfiguration(
             "applyJunit5Support=$applyJunit5Support,\n" +
             "springDevTools=$springDevTools,\n" +
             "useWebFlux=$useWebFlux,\n" +
+            "usePython=$usePython,\n" +
             "useBootJar=$useBootJar,\n" +
             "useAuroraStarters=$useAuroraStarters)"
 }
@@ -98,6 +100,7 @@ fun Project.getConfig(): AuroraConfiguration {
         applyJunit5Support = features.junit5Support ?: props.asBoolean("applyJunit5Support") ?: Features.applyJunit5Support,
         springDevTools = features.springDevTools ?: props.asBoolean("springDevTools") ?: Features.springDevTools,
         useWebFlux = spring.webFluxEnabled ?: props.asBoolean("useWebFlux") ?: Features.useWebFlux,
+        usePython = features.python ?: props.asBoolean("usePython") ?: Features.usePython,
         useBootJar = spring.bootJarEnabled ?: props.asBoolean("useBootJar") ?: Features.useBootJar,
         useAuroraStarters = features.auroraStarters ?: props.asBoolean("useAuroraStarters") ?: Features.useAuroraStarters
     )

--- a/src/main/kotlin/no/skatteetaten/aurora/gradle/plugins/mutators/AuroraTools.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gradle/plugins/mutators/AuroraTools.kt
@@ -7,7 +7,43 @@ import org.gradle.api.tasks.bundling.Tar
 import org.gradle.kotlin.dsl.named
 
 class AuroraTools(private val project: Project) {
-    fun applyDeliveryBundleConfig(bootJar: Boolean): AuroraReport = when {
+    fun applyDeliveryBundleConfig(python: Boolean, bootJar: Boolean): AuroraReport = when {
+        python -> {
+            project.logger.lifecycle("Apply python delivery bundle")
+
+            with(project) {
+                plugins.apply("distribution")
+
+                with(extensions.getByName("distributions") as DistributionContainer) {
+                    with(getByName("main")) {
+                        with(contents) {
+                            from("${project.buildDir}/resources/main") {
+                                it.into("src")
+                            }
+
+                            from("${project.projectDir}/src/main/dist/metadata") {
+                                it.into("metadata")
+                            }
+                        }
+                    }
+                }
+
+                with(tasks.named("distZip", org.gradle.api.tasks.bundling.Zip::class).get()) {
+                    archiveClassifier.set("Leveransepakke")
+                    duplicatesStrategy = org.gradle.api.file.DuplicatesStrategy.EXCLUDE
+
+                    dependsOn("processResources")
+                }
+
+                disableSuperfluousArtifacts()
+            }
+
+            AuroraReport(
+                name = "aurora.applyDeliveryBundleConfig",
+                pluginsApplied = listOf("distribution"),
+                description = "Configure Leveransepakke for python"
+            )
+        }
         bootJar -> {
             project.logger.lifecycle("Apply bootjar delivery bundle")
 
@@ -52,6 +88,8 @@ class AuroraTools(private val project: Project) {
 
                 with(tasks.named("distZip", org.gradle.api.tasks.bundling.Zip::class).get()) {
                     archiveClassifier.set("Leveransepakke")
+
+                    dependsOn("jar")
                 }
 
                 disableSuperfluousArtifacts()

--- a/src/main/kotlin/no/skatteetaten/aurora/gradle/plugins/mutators/MavenTools.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gradle/plugins/mutators/MavenTools.kt
@@ -9,7 +9,7 @@ import org.gradle.kotlin.dsl.withConvention
 import org.gradle.kotlin.dsl.withGroovyBuilder
 
 class MavenTools(private val project: Project) {
-    fun addMavenDeployer(): AuroraReport = when {
+    fun addMavenDeployer(python: Boolean = false): AuroraReport = when {
         missingRepositoryConfiguration() -> AuroraReport(
             name = "aurora.applyMavenDeployer",
             description = MISSING_REPO_CREDS_MESSAGE
@@ -26,6 +26,7 @@ class MavenTools(private val project: Project) {
             with(project) {
                 with(tasks) {
                     configureDeployer(
+                        python,
                         repositoryReleaseUrl,
                         repositoryUsername,
                         repositoryPassword,
@@ -53,12 +54,17 @@ class MavenTools(private val project: Project) {
     }
 
     private fun TaskContainer.configureDeployer(
+        python: Boolean,
         repositoryReleaseUrl: String,
         repositoryUsername: String,
         repositoryPassword: String,
         repositorySnapshotUrl: String
     ) = named("uploadArchives", Upload::class.java) {
         with(it) {
+            if (python) {
+                isUploadDescriptor = false
+            }
+
             with(repositories) {
                 withConvention(MavenRepositoryHandlerConvention::class) {
                     with(mavenDeployer()) {

--- a/src/test/kotlin/no/skatteetaten/aurora/gradle/plugins/unit/JavaToolsTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/gradle/plugins/unit/JavaToolsTest.kt
@@ -128,9 +128,9 @@ class JavaToolsTest {
         val metaEntry = zipEntries.find { it.name.endsWith("metadata/") }
         val metaEntryCount = zipEntries.filter { it.name.contains("Leveransepakke/metadata") }
 
-        assertThat(libEntry?.isDirectory ?: false).isTrue()
+        assertThat(libEntry?.isDirectory).isNotNull().isTrue()
         assertThat(libEntryCount.size).isEqualTo(2)
-        assertThat(metaEntry?.isDirectory ?: false).isTrue()
+        assertThat(metaEntry?.isDirectory).isNotNull().isTrue()
         assertThat(metaEntryCount.size).isEqualTo(2)
         assertThat(result.taskOutcome()).isSuccessOrEqualTo()
     }
@@ -189,9 +189,9 @@ class JavaToolsTest {
         val metaEntry = jarAsZip.entries().toList().find { it.name.endsWith("metadata/") }
 
         assertThat(libEntry).isNotNull()
-        assertThat(libEntry?.isDirectory ?: false).isTrue()
+        assertThat(libEntry?.isDirectory).isNotNull().isTrue()
         assertThat(metaEntry).isNotNull()
-        assertThat(metaEntry?.isDirectory ?: false).isTrue()
+        assertThat(metaEntry?.isDirectory).isNotNull().isTrue()
         assertThat(result.taskOutcome()).isSuccessOrEqualTo()
     }
 


### PR DESCRIPTION
This is part of a bigger initiative to enable python apps

The idea here is to package a python app with req.txt so architect can install deps with pip as a standard leveransepakke, with a modified format for use with the python images in the pipeline.

This also enables us to produce python applications with the gradle plugin, see internal test app 'python-test' for an example.