### PR TITLE
AOS-6312: Oppdaterer Tomcat

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,2 @@
 version=local-SNAPSHOT
 group=no.skatteetaten.aurora.gradle.plugins
-tomcat.version=9.0.58

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 version=local-SNAPSHOT
 group=no.skatteetaten.aurora.gradle.plugins
+tomcat.version=9.0.58

--- a/src/main/kotlin/no/skatteetaten/aurora/gradle/plugins/mutators/SpringTools.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gradle/plugins/mutators/SpringTools.kt
@@ -41,7 +41,7 @@ class SpringTools(private val project: Project) {
         project.logger.lifecycle("Apply Spring support")
 
         with(project) {
-            extra.set("tomcat.version", "9.0.58")
+            extra.set("tomcat.version", "9.0.58") // TODO: Remove this when Spring upgrades to use this version
             with(plugins) {
                 apply("io.spring.dependency-management")
             }

--- a/src/main/kotlin/no/skatteetaten/aurora/gradle/plugins/mutators/SpringTools.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gradle/plugins/mutators/SpringTools.kt
@@ -4,6 +4,7 @@ import io.spring.gradle.dependencymanagement.dsl.DependencyManagementExtension
 import no.skatteetaten.aurora.gradle.plugins.model.AuroraReport
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.exclude
+import org.gradle.kotlin.dsl.extra
 import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.named
 import org.springframework.boot.gradle.dsl.SpringBootExtension
@@ -40,6 +41,7 @@ class SpringTools(private val project: Project) {
         project.logger.lifecycle("Apply Spring support")
 
         with(project) {
+            extra.set("tomcat.version", "9.0.58")
             with(plugins) {
                 apply("io.spring.dependency-management")
             }


### PR DESCRIPTION
Denne oppdateringen er nødvendig p.g.a. [en sikkerhetsfeil](https://nvd.nist.gov/vuln/detail/CVE-2022-23181).
Den nye versjonen av Tomcat vil være inkludert i neste versjon av Spring Boot, så når den kommer, kan denne linjen fjernes igjen.