### PR TITLE
SITJ-2211 register task "auroraCyclonedxBom" programmatically configured

### DIFF
--- a/src/main/kotlin/no/skatteetaten/aurora/gradle/plugins/AuroraPlugin.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/gradle/plugins/AuroraPlugin.kt
@@ -15,12 +15,14 @@ import no.skatteetaten.aurora.gradle.plugins.extensions.UseSpringBoot
 import no.skatteetaten.aurora.gradle.plugins.extensions.Versions
 import no.skatteetaten.aurora.gradle.plugins.model.AuroraReport
 import no.skatteetaten.aurora.gradle.plugins.model.getConfig
+import org.cyclonedx.gradle.CycloneDxTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.register
 
 @Suppress("unused")
 @ExperimentalStdlibApi
@@ -83,6 +85,14 @@ class AuroraPlugin : Plugin<Project> {
                             project.logger.lifecycle(config.toString())
                         }
                     }
+                }
+
+                register<CycloneDxTask>("auroraCyclonedxBom") {
+                    setIncludeConfigs(listOf("runtimeClasspath"))
+                    setProjectType("application")
+                    setSchemaVersion("1.4")
+                    setDestination(project.file("build/reports"))
+                    setOutputName("bom")
                 }
             }
         }


### PR DESCRIPTION
Viste seg at [cyclonedx-gradle-plugin](https://github.com/CycloneDX/cyclonedx-gradle-plugin) tar med for mye når den kjøres med default config. Det ser ikke ut som pluginen tar imot ProsjektParametre fra kommandolinje, så derfor prøvde jeg å finne ut hvordan konfigurere det programmatisk.

Fant denne metoden - registrere en ny task med konfig. Men det må vel være en bedre måte å gjøre det på?